### PR TITLE
[dy] Update singer get_logger method

### DIFF
--- a/singer/logger.py
+++ b/singer/logger.py
@@ -5,16 +5,25 @@ import os
 
 def get_logger():
     """Return a Logger instance appropriate for using in a Tap or a Target."""
-    this_dir, _ = os.path.split(__file__)
-    path = os.path.join(this_dir, 'logging.conf')
+    # this_dir, _ = os.path.split(__file__)
+    # path = os.path.join(this_dir, 'logging.conf')
     # See
     # https://docs.python.org/3.5/library/logging.config.html#logging.config.fileConfig
     # for a discussion of why or why not to set disable_existing_loggers
     # to False. The long and short of it is that if you don't set it to
     # False it ruins external module's abilities to use the logging
     # facility.
-    logging.config.fileConfig(path, disable_existing_loggers=False)
-    return logging.getLogger()
+    # logging.config.fileConfig(path, disable_existing_loggers=False)
+    logger = logging.getLogger('singer')
+
+    logger.setLevel(logging.INFO)
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter('%(levelname)s %(message)s'))
+    for h in logger.handlers[:]:
+        logger.removeHandler(h)
+    logger.addHandler(handler)
+
+    return logger
 
 
 def log_debug(msg, *args, **kwargs):


### PR DESCRIPTION
# Description of change
(write a short description or paste a link to JIRA)

The `singer.get_logger` method was overwriting the root logger every time it was called, so this PR updates the logic to return a singer specific logger instead.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
